### PR TITLE
[ohos] Fix memory leak of ArkUIRootView

### DIFF
--- a/compose/ui/ui-arkui/src/ohosArm64Main/cpp/compose/src/main/ets/compose/ArkUIRootView.ets
+++ b/compose/ui/ui-arkui/src/ohosArm64Main/cpp/compose/src/main/ets/compose/ArkUIRootView.ets
@@ -48,5 +48,6 @@ export class ArkUIRootView extends NodeController {
 
   removeSubView(view: ArkUIView) {
     this.frameNode.removeChild(view)
+    view.dispose()
   }
 }


### PR DESCRIPTION
## Proposed Changes

  -add disposal of SubView after removed

## Testing

In the ohos mixed scene, native memory usage increases significantly with sliding and page jumps, which is significantly reduced after modification.

## Google CLA
You need to sign the Google Contributor’s License Agreement at https://cla.developers.google.com/.
This is needed since we synchronise most of the code with Google’s AOSP repository. Signing this agreement allows us to synchronise code from your Pull Requests as well.
