### PR TITLE
Clamp AndroidFlingSpline.flingPosition to prevent array OOB

### DIFF
--- a/compose/animation/animation/src/androidUnitTest/kotlin/androidx/compose/animation/AndroidFlingSplineTest.kt
+++ b/compose/animation/animation/src/androidUnitTest/kotlin/androidx/compose/animation/AndroidFlingSplineTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.animation
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class AndroidFlingSplineTest {
+
+    @Test
+    fun testClampedOutOfRangePosition() {
+        val controlStart = AndroidFlingSpline.flingPosition(0f)
+        val controlEnd = AndroidFlingSpline.flingPosition(1f)
+
+        assertEquals(controlStart, AndroidFlingSpline.flingPosition(-10f))
+        assertEquals(controlStart, AndroidFlingSpline.flingPosition(-1f))
+        assertEquals(controlStart, AndroidFlingSpline.flingPosition(-0.06f))
+
+        assertEquals(controlEnd, AndroidFlingSpline.flingPosition(1.5f))
+        assertEquals(controlEnd, AndroidFlingSpline.flingPosition(10f))
+    }
+}

--- a/compose/animation/animation/src/commonMain/kotlin/androidx/compose/animation/SplineBasedDecay.kt
+++ b/compose/animation/animation/src/commonMain/kotlin/androidx/compose/animation/SplineBasedDecay.kt
@@ -87,7 +87,10 @@ internal object AndroidFlingSpline {
      * @param time progress through the fling animation from 0-1
      */
     fun flingPosition(time: Float): FlingResult {
-        val index = (NbSamples * time).toInt()
+        // We clamp the time to prevent crashes from a clock providing playTime values lower than
+        // the start time, which leads to an IOO here. See b/313685022.
+        val clampedTime = time.coerceIn(0f, 1f)
+        val index = (NbSamples * clampedTime).toInt()
         var distanceCoef = 1f
         var velocityCoef = 0f
         if (index < NbSamples) {
@@ -96,7 +99,7 @@ internal object AndroidFlingSpline {
             val dInf = SplinePositions[index]
             val dSup = SplinePositions[index + 1]
             velocityCoef = (dSup - dInf) / (tSup - tInf)
-            distanceCoef = dInf + (time - tInf) * velocityCoef
+            distanceCoef = dInf + (clampedTime - tInf) * velocityCoef
         }
         return FlingResult(
             distanceCoefficient = distanceCoef,


### PR DESCRIPTION
## Summary
- Port the AndroidX compose-animation 1.7.0 clamp (`9d47587`, b/313685022) into this 1.6.1 tree.
- A non-monotonic frame clock can feed a play time before animation start, so `index = (NbSamples * time).toInt()` goes negative and Kotlin Native throws `ArrayIndexOutOfBoundsException` (Tencent-TDS/ovCompose-multiplatform-core#18).
- Clamp `time` to `[0, 1]` before indexing. Same workaround that shipped upstream.

## Test plan
- [x] `AndroidFlingSplineTest#testClampedOutOfRangePosition` — out-of-range inputs (`-10`, `-1`, `-0.06`, `1.5`, `10`) match the `0`/`1` endpoints and do not throw.

Fixes #18