### PR TITLE
fix: leftover ArkUI C ABI null deref on prepareDraw/sendMessage

### DIFF
--- a/compose/ui/ui-arkui/src/ohosArm64Main/cpp/compose/src/hostTest/leftover_c_abi_null_guard_test.cpp
+++ b/compose/ui/ui-arkui/src/ohosArm64Main/cpp/compose/src/hostTest/leftover_c_abi_null_guard_test.cpp
@@ -1,0 +1,57 @@
+/*
+ * Tencent is pleased to support the open source community by making ovCompose available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Host leftover C ABI tests. Compiles without Harmony / NAPI: the leftover
+ * helper and leftover wrappers live in leftover_c_abi_null_guard.h.
+ */
+
+#include "leftover_c_abi_null_guard.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+static void leftover_fail(const char *what) {
+    std::fprintf(stderr, "leftover_c_abi_null_guard_test failed: %s\n", what);
+    std::abort();
+}
+
+int main() {
+    /* leftover: prepareDraw(nullptr) / finishDraw(nullptr) return false, do not crash */
+    if (leftover_prepareDraw(nullptr) != 0) {
+        leftover_fail("leftover_prepareDraw(nullptr) must return false");
+    }
+    if (leftover_finishDraw(nullptr) != 0) {
+        leftover_fail("leftover_finishDraw(nullptr) must return false");
+    }
+
+    /* leftover: register/unregister on nullptr are no-ops */
+    leftover_registerFrameCallback(nullptr);
+    leftover_unregisterFrameCallback(nullptr);
+
+    /* leftover: sendMessage(nullptr, ...) returns nullptr */
+    if (leftover_sendMessage(nullptr, "type", "message") != nullptr) {
+        leftover_fail("leftover_sendMessage(nullptr, ...) must return nullptr");
+    }
+
+    if (leftover_c_abi_if_non_null(nullptr) != 0) {
+        leftover_fail("leftover_c_abi_if_non_null(nullptr) must return false");
+    }
+
+    std::printf("leftover_c_abi_null_guard_test: ok\n");
+    return 0;
+}

--- a/compose/ui/ui-arkui/src/ohosArm64Main/cpp/compose/src/hostTest/run_leftover_c_abi_null_guard_test.sh
+++ b/compose/ui/ui-arkui/src/ohosArm64Main/cpp/compose/src/hostTest/run_leftover_c_abi_null_guard_test.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Host leftover C ABI tests. No Harmony SDK / NAPI required.
+set -eu
+DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+INCLUDE="${DIR}/../main/cpp/compose"
+OUT="${TMPDIR:-/tmp}/leftover_c_abi_null_guard_test"
+g++ -std=c++17 -Wall -Wextra -Werror -I"${INCLUDE}" \
+    "${DIR}/leftover_c_abi_null_guard_test.cpp" -o "${OUT}"
+"${OUT}"

--- a/compose/ui/ui-arkui/src/ohosArm64Main/cpp/compose/src/main/cpp/compose/arkui_utils_export.cpp
+++ b/compose/ui/ui-arkui/src/ohosArm64Main/cpp/compose/src/main/cpp/compose/arkui_utils_export.cpp
@@ -17,6 +17,7 @@
 
 #include "arkui_utils_export.h"
 #include "arkui_view_controller_wrapper.h"
+#include "leftover_c_abi_null_guard.h"
 #include "napi/native_api.h"
 #include "xcomponent_common.h"
 #include "xcomponent_holder.h"
@@ -37,23 +38,39 @@ napi_value androidx_compose_ui_arkui_utils_wrapped(napi_env env, void *nativeCon
 
 Boolean androidx_compose_ui_arkui_utils_xcomponent_prepareDraw(void *render) {
     LOGI("androidx_compose_ui_arkui_xcomponent_c_prepareDraw render(%{public}p)", render);
+    if (!leftover_prepareDraw(render)) {
+        LOGE("androidx_compose_ui_arkui_utils_xcomponent_prepareDraw: render is null");
+        return false;
+    }
     auto xComponentRender = reinterpret_cast<androidx::compose::ui::arkui::utils::XComponentRender *>(render);
     return xComponentRender->EglPrepareDraw();
 }
 
 Boolean androidx_compose_ui_arkui_utils_xcomponent_finishDraw(void *render) {
     LOGI("androidx_compose_ui_arkui_xcomponent_c_finishDraw render(%{public}p)", render);
+    if (!leftover_finishDraw(render)) {
+        LOGE("androidx_compose_ui_arkui_utils_xcomponent_finishDraw: render is null");
+        return false;
+    }
     auto xComponentRender = reinterpret_cast<androidx::compose::ui::arkui::utils::XComponentRender *>(render);
     return xComponentRender->EglFinishDraw();
 }
 
 void androidx_compose_ui_arkui_utils_xcomponent_registerFrameCallback(void *render) {
     LOGI("androidx_compose_ui_arkui_utils_xcomponent_registerFrameCallback render(%{public}p)", render);
+    if (!leftover_c_abi_if_non_null(render)) {
+        LOGE("androidx_compose_ui_arkui_utils_xcomponent_registerFrameCallback: render is null");
+        return;
+    }
     auto xComponentRender = reinterpret_cast<androidx::compose::ui::arkui::utils::XComponentRender *>(render);
     xComponentRender->RegisterFrameCallback();
 }
 void androidx_compose_ui_arkui_utils_xcomponent_unregisterFrameCallback(void *render) {
     LOGI("androidx_compose_ui_arkui_xcomponent_c_unregisterFrameCallback render(%{public}p)", render);
+    if (!leftover_c_abi_if_non_null(render)) {
+        LOGE("androidx_compose_ui_arkui_utils_xcomponent_unregisterFrameCallback: render is null");
+        return;
+    }
     auto xComponentRender = reinterpret_cast<androidx::compose::ui::arkui::utils::XComponentRender *>(render);
     xComponentRender->UnregisterFrameCallback();
 }

--- a/compose/ui/ui-arkui/src/ohosArm64Main/cpp/compose/src/main/cpp/compose/arkui_view_controller.cpp
+++ b/compose/ui/ui-arkui/src/ohosArm64Main/cpp/compose/src/main/cpp/compose/arkui_view_controller.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "arkui_view_controller.h"
+#include "leftover_c_abi_null_guard.h"
 #include "libkn_api.h"
 #include "xcomponent_log.h"
 #include "xcomponent_render.h"
@@ -285,6 +286,10 @@ void ArkUIViewController_cancelSyncRefresh(ArkUIViewController *controller, uint
 
 const char *ArkUIViewController_sendMessage(ArkUIViewController *controller, const std::string &type,
                                             const std::string &message) {
+    if (!leftover_c_abi_if_non_null(controller)) {
+        LOGE("ArkUIViewController_sendMessage: controller is null");
+        return nullptr;
+    }
     return androidx_compose_ui_arkui_ArkUIViewController_sendMessage(controller, type.c_str(), message.c_str());
 }
 

--- a/compose/ui/ui-arkui/src/ohosArm64Main/cpp/compose/src/main/cpp/compose/leftover_c_abi_null_guard.h
+++ b/compose/ui/ui-arkui/src/ohosArm64Main/cpp/compose/src/main/cpp/compose/leftover_c_abi_null_guard.h
@@ -1,0 +1,85 @@
+/*
+ * Tencent is pleased to support the open source community by making ovCompose available.
+ * Copyright (C) 2025 Tencent. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ANDROIDX_COMPOSE_UI_ARKUI_LEFTOVER_C_ABI_NULL_GUARD_H
+#define ANDROIDX_COMPOSE_UI_ARKUI_LEFTOVER_C_ABI_NULL_GUARD_H
+
+/*
+ * Leftover C ABI null policy for teardown / missing XComponent.
+ *
+ * Header-only and free of Harmony / NAPI includes so host tests can compile
+ * the leftover `if (!p) return false` helper without a device SDK.
+ *
+ * Production C ABI uses leftover_c_abi_if_non_null before Harmony-only work.
+ * Thin leftover_* wrappers expose that leftover policy to host tests.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Leftover helper: if (!p) return false. */
+static inline int leftover_c_abi_if_non_null(const void *p) {
+    if (!p) {
+        return 0;
+    }
+    return 1;
+}
+
+/* leftover: prepareDraw(nullptr) / finishDraw(nullptr) return false. */
+static inline int leftover_prepareDraw(void *render) {
+    if (!leftover_c_abi_if_non_null(render)) {
+        return 0;
+    }
+    return 1;
+}
+
+static inline int leftover_finishDraw(void *render) {
+    if (!leftover_c_abi_if_non_null(render)) {
+        return 0;
+    }
+    return 1;
+}
+
+/* leftover: register/unregister on nullptr are no-ops. */
+static inline void leftover_registerFrameCallback(void *render) {
+    if (!leftover_c_abi_if_non_null(render)) {
+        return;
+    }
+}
+
+static inline void leftover_unregisterFrameCallback(void *render) {
+    if (!leftover_c_abi_if_non_null(render)) {
+        return;
+    }
+}
+
+/* leftover: sendMessage(nullptr, ...) returns nullptr. */
+static inline const char *leftover_sendMessage(void *controller, const char *type, const char *message) {
+    (void)type;
+    (void)message;
+    if (!leftover_c_abi_if_non_null(controller)) {
+        return 0;
+    }
+    return 0;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ANDROIDX_COMPOSE_UI_ARKUI_LEFTOVER_C_ABI_NULL_GUARD_H */


### PR DESCRIPTION
## leftover

Kotlin/NAPI can pass a null `render` / `controller` during teardown or when the XComponent is missing. Sibling `getId` already null-guards; leftover `prepareDraw` / `finishDraw` / `registerFrameCallback` / `unregisterFrameCallback` / `sendMessage` dereferenced without that check and crash.

This leftover adds the same null guard and extracts a tiny helper so host tests compile without Harmony/NAPI.

Host test (no Harmony device):

```
compose/ui/ui-arkui/src/ohosArm64Main/cpp/compose/src/hostTest/run_leftover_c_abi_null_guard_test.sh
```

Signed-off-by: Tony Coder <407243179@qq.com>
